### PR TITLE
feat(services): add hydra service to extractors

### DIFF
--- a/nixos/extractors/services.nix
+++ b/nixos/extractors/services.nix
@@ -94,6 +94,13 @@ in {
         );
       };
 
+      hydra = mkIf config.services.hydra.enable {
+        name = "Hydra";
+        icon = "devices.nixos";
+        info = config.services.hydra.hydraURL;
+        details.listen.text = "${config.services.hydra.listenHost}:${toString config.services.hydra.port}";
+      };
+
       influxdb2 = mkIf config.services.influxdb2.enable {
         name = "InfluxDB v2";
         icon = "services.influxdb2";


### PR DESCRIPTION
Adds the hydra service, reutilises the nixos device logo as the hydra project doesn't seem to have it's own logo. It might be possible that the contributors of [this project](https://github.com/nlewo/hydra-cli) would be happy for us to modify their logo - but for now I figured a simple reuse of nixos makes sense given hydra's general offering :smile: 