### PR TITLE
feat(services): add nix-serve service to extractors

### DIFF
--- a/nixos/extractors/services.nix
+++ b/nixos/extractors/services.nix
@@ -191,6 +191,12 @@ in {
         }://${config.services.nextcloud.hostName}";
       };
 
+      nix-serve = mkIf config.services.nix-serve.enable {
+        name = "Nix Serve";
+        icon = "devices.nixos";
+        details.listen.text = "${config.services.nix-serve.bindAddress}:${toString config.services.nix-serve.port}";
+      };
+
       nginx = mkIf config.services.nginx.enable {
         name = "NGINX";
         icon = "services.nginx";


### PR DESCRIPTION
Extremely basic one - again had to use the nixos device icon as no clear branding exists for this one.
Just as with hydra this service exists explicitly to enable nixos related material, so I figure we could re-use the icon again