### PR TITLE
Fix syntax

### DIFF
--- a/nixos/extractors/services.nix
+++ b/nixos/extractors/services.nix
@@ -79,15 +79,15 @@ in {
         details = genAttrs (mapAttrsToList (name: _: name) config.services.caddy.virtualHosts) (name: {
           text =
             concatStringsSep " " # Turn the (possibly multiple) strings in the list into a single string
-            
+
             (builtins.map
               (line: removePrefix "reverse_proxy " line) # Remove the prefix, so only the list of hosts are left
-              
+
               (filter (line: hasPrefix "reverse_proxy " line) # Filter out lines that don't start with reverse_proxy
-                
+
                 (splitString "\n" config.services.caddy.virtualHosts.${name}.extraConfig))); # Separate lines of string into list
         });
-        
+
       dnsmasq = mkIf config.services.dnsmasq.enable {
         name = "Dnsmasq";
         icon = "services.dnsmasq";
@@ -442,6 +442,6 @@ in {
         info = cfg.repository;
         details.paths.text = toString cfg.paths;
       }
-    )
-  );
+    );
+  });
 }


### PR DESCRIPTION
Otherwise things just crash 😅 

```
       … while calling the 'seq' builtin
         at /nix/store/3ghj5179lskashxcbl0wm0n7x3wz7i3p-source/lib/modules.nix:322:18:
          321|         options = checked options;
          322|         config = checked (removeAttrs config [ "_module" ]);
             |                  ^
          323|         _module = checked (config._module);

       … while evaluating a branch condition
         at /nix/store/3ghj5179lskashxcbl0wm0n7x3wz7i3p-source/lib/modules.nix:261:9:
          260|       checkUnmatched =
          261|         if config._module.check && config._module.freeformType == null && merged.unmatchedDefns != [] then
             |         ^
          262|           let

       (stack trace truncated; use '--show-trace' to show the full trace)

       error: syntax error, unexpected ')', expecting ';'
       at /nix/store/f4192dv6vgl9dhhjnsyajika834l1fml-source/nixos/extractors/services.nix:446:3:
          445|     )
          446|   );
             |   ^
          447| }
```