### PR TITLE
fix(extractors/services): misplaced bracket caused blank service renders

### DIFF
--- a/nixos/extractors/services.nix
+++ b/nixos/extractors/services.nix
@@ -79,14 +79,15 @@ in {
         details = genAttrs (mapAttrsToList (name: _: name) config.services.caddy.virtualHosts) (name: {
           text =
             concatStringsSep " " # Turn the (possibly multiple) strings in the list into a single string
-
+            
             (builtins.map
               (line: removePrefix "reverse_proxy " line) # Remove the prefix, so only the list of hosts are left
-
+              
               (filter (line: hasPrefix "reverse_proxy " line) # Filter out lines that don't start with reverse_proxy
-
+                
                 (splitString "\n" config.services.caddy.virtualHosts.${name}.extraConfig))); # Separate lines of string into list
         });
+      };
 
       dnsmasq = mkIf config.services.dnsmasq.enable {
         name = "Dnsmasq";
@@ -442,6 +443,6 @@ in {
         info = cfg.repository;
         details.paths.text = toString cfg.paths;
       }
-    );
-  });
+    )
+  );
 }


### PR DESCRIPTION
This PR https://github.com/oddlama/nix-topology/pull/23 attempted to fix syntax issue, but caused service renders to be blank https://github.com/oddlama/nix-topology/issues/24. 

![image](https://github.com/oddlama/nix-topology/assets/79340822/79ae526e-5d95-4c67-b7cf-0883e3a96a3c)

Turns out the original issue was just a missing bracket

![image](https://github.com/oddlama/nix-topology/assets/79340822/d1a22d6b-e3cc-4f49-b37b-a958f15dbb0e)
