### PR TITLE
feat(extractors/services/grafana): list plugins

### DIFF
--- a/nixos/extractors/services.nix
+++ b/nixos/extractors/services.nix
@@ -153,12 +153,16 @@ in {
       grafana = let
         address = config.services.grafana.settings.server.http_addr or null;
         port = config.services.grafana.settings.server.http_port or null;
+        plugins = config.services.grafana.declarativePlugins;
       in
         mkIf config.services.grafana.enable {
           name = "Grafana";
           icon = "services.grafana";
           info = config.services.grafana.settings.server.root_url;
-          details.listen = mkIf (address != null && port != null) {text = "${address}:${toString port}";};
+          details = {
+            listen = mkIf (address != null && port != null) {text = "${address}:${toString port}";};
+            plugins = mkIf (plugins != null) {text = concatStringsSep "\n" (builtins.map (p: p.name) plugins);};
+          };
         };
 
       headscale = mkIf config.services.headscale.enable {


### PR DESCRIPTION
I thought it would be useful to detail the plugins that are installed on the grafana instances (when they are installed declaratively).
I am not too sure if the rendering is the best, but it seemed to require a string with values separated by `\n`.

Here is what it looks like:

![2024-05-09T18:36:28,204691883+02:00](https://github.com/oddlama/nix-topology/assets/2647236/f31fd2d3-a220-497c-9663-c6d8b4bdcf9f)

Feedback appreciated, and thanks for this awesome project! :slightly_smiling_face: