### PR TITLE
fix(extractors/services): Rename obsolete option services.oauth2_proxy

### DIFF
--- a/nixos/extractors/services.nix
+++ b/nixos/extractors/services.nix
@@ -303,10 +303,10 @@ in {
           mkMerge reverseProxies;
       };
 
-      oauth2_proxy = mkIf config.services.oauth2_proxy.enable {
+      oauth2-proxy = mkIf config.services.oauth2-proxy.enable {
         name = "OAuth2 Proxy";
         icon = "services.oauth2-proxy";
-        info = config.services.oauth2_proxy.httpAddress;
+        info = config.services.oauth2-proxy.httpAddress;
       };
 
       openssh = mkIf config.services.openssh.enable {


### PR DESCRIPTION
When building with latest nixpkgs unstable you get lots of warnings: 
```trace: Obsolete option `services.oauth2_proxy' is used. It was renamed to `services.oauth2-proxy'.```

Renamed the service and tested render with `services.oauth2-proxy.enable = true`

![image](https://github.com/oddlama/nix-topology/assets/79340822/dcbdbbaa-3e78-4b8b-9c95-56693a0a98a4)
