### PR TITLE
fix(extractors/services): allow dnsmasq without address

### DIFF
--- a/nixos/extractors/services.nix
+++ b/nixos/extractors/services.nix
@@ -93,7 +93,7 @@ in {
         name = "Dnsmasq";
         icon = "services.dnsmasq";
         details = let
-          addresses = config.services.dnsmasq.settings.address;
+          addresses = config.services.dnsmasq.settings.address or [];
         in
           listToAttrs (forEach
             (forEach addresses


### PR DESCRIPTION
dnsmasq can be configured without addresses, so we should not require the field.