### PR TITLE
fix(renderers/svg): respect service details' order

### DIFF
--- a/topology/renderers/svg/default.nix
+++ b/topology/renderers/svg/default.nix
@@ -14,6 +14,7 @@
     head
     mkOption
     optionalString
+    sort
     splitString
     tail
     types
@@ -188,8 +189,14 @@
 
       serviceDetails = service:
         optionalString (service.details != {}) ''<div tw="flex pt-2"></div>''
-        # FIXME: order not respected
-        + concatLines ((map serviceDetail) (attrValues service.details));
+        + concatLines ((map serviceDetail) (
+          flip sort (attrValues service.details) (
+            a: b:
+              if a.order != b.order
+              then a.order < b.order
+              else a.name < b.name
+          )
+        ));
 
       mkService = {
         additionalInfo ? "",


### PR DESCRIPTION
First of all, thank you so much for open-sourcing this wonderful project! I find it a quite elegant solution, not only in terms of ergonomics, but also because of its aesthetics!

## What and How

Addresses `renderers/svg` [FIXME comment](https://github.com/oddlama/nix-topology/blob/870dcc9074077a327220b36597098c295944a47d/topology/renderers/svg/default.nix#L191-L192) by implementing the service details' order; makes use of the `order` field, as documented and specified in [`options/services.nix`](https://github.com/oddlama/nix-topology/blob/870dcc9074077a327220b36597098c295944a47d/options/services.nix#L68-L72).

Defaults to `name`s lexicographical order in case of an `order` tie (e.g. when `order` is not specified), which feels like the (current and) expected behavior.

### Snippet

```nix
{
  # ...
  details.http = {
    text = toString config.services.tvheadend.httpPort;
    order = 1;
  };
  details.htsp = {
    text = toString config.services.tvheadend.htspPort;
    order = 2;
  };
}
```

### Before

![before](https://github.com/user-attachments/assets/38740a5b-3bef-467e-9bb0-993aa3f01427)

### After

![after](https://github.com/user-attachments/assets/6b0f6b26-abcb-4735-8379-87409129bc89)

## Checklist

- [x] `nix flake check`
- [x] `nix build .#docs`
- [x] Conventional Commits

Please let me know if something's off or missing, and once again thank you for your work.