### PR TITLE
fix: flakeModule with pkgs containing overlays

### DIFF
--- a/flake-module.nix
+++ b/flake-module.nix
@@ -56,7 +56,7 @@ in {
         pkgs = mkOption {
           type = types.unspecified;
           description = "The package set to use for the topology evaluation on this system.";
-          default = pkgs;
+          default = pkgs.extend (import ./pkgs/default.nix);
           defaultText = lib.literalExpression "pkgs # (module argument)";
         };
         modules = mkOption {


### PR DESCRIPTION
Fixes #36 to make flakeModules work out of the box.

I tried to use `pkgs.extend self.overlays.default` but couldn't make it work.