### PR TITLE
fix: strip block suffixes in Caddy extractor

### DIFF
--- a/nixos/extractors/services.nix
+++ b/nixos/extractors/services.nix
@@ -30,6 +30,7 @@
     replaceStrings
     splitString
     removePrefix
+    removeSuffix
     hasPrefix
     filter
     tail
@@ -81,7 +82,7 @@ in {
             concatStringsSep " " # Turn the (possibly multiple) strings in the list into a single string
             
             (builtins.map
-              (line: removePrefix "reverse_proxy " line) # Remove the prefix, so only the list of hosts are left
+              (line: removePrefix "reverse_proxy " (removeSuffix " {" line)) # Remove the prefix and suffix, so only the list of hosts are left
               
               (filter (line: hasPrefix "reverse_proxy " line) # Filter out lines that don't start with reverse_proxy
                 


### PR DESCRIPTION
Caddy `reverse_proxy` blocks have [configuration options](https://caddyserver.com/docs/caddyfile/directives/reverse_proxy#syntax) which can result in the syntax looking like [this](
https://github.com/msfjarvis/dotfiles/blob/029d06e41a16b30980bd5a052c056cb055db403a/modules/nixos/prometheus/default.nix#L31-L33) that causes the extractor to pick up addresses as `127.0.0.1:1234 {` rather than the expected `127.0.0.1:1234`.