### PR TITLE
feat(extractors/systemd-network): Add support for network `addresses` array

### DIFF
--- a/nixos/extractors/systemd-network.nix
+++ b/nixos/extractors/systemd-network.nix
@@ -7,6 +7,7 @@
     (lib)
     any
     attrValues
+    catAttrs
     concatLists
     concatStringsSep
     filter
@@ -113,7 +114,7 @@ in {
                 {
                   ${interfaceName} = {
                     mac = mkIf ((network.matchConfig.MACAddress or null) != null) network.matchConfig.MACAddress;
-                    addresses = map removeCidrMask (network.address ++ (network.networkConfig.Address or []));
+                    addresses = map removeCidrMask (network.address ++ (catAttrs "Address" network.addresses) ++ (network.networkConfig.Address or []));
                     gateways = network.gateway ++ (network.networkConfig.Gateway or []);
                   };
                 }


### PR DESCRIPTION
Note, it only supports the new format, i.e. not the old "addressConfig = {...}" format.