### PR TITLE
nix flake check worflow

### DIFF
--- a/.github/workflows/check-flake.yml
+++ b/.github/workflows/check-flake.yml
@@ -1,0 +1,22 @@
+name: Check Nix Flake
+on:
+  pull_request:
+permissions:
+  contents: read
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+jobs:
+  flake-check:
+    name: Check Nix Flake
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@main
+      - name: Setup Nix Cache
+        uses: DeterminateSystems/magic-nix-cache-action@main
+      - name: Check Nix Flake
+        shell: bash
+        run: nix flake check

--- a/.github/workflows/flake-publish-rolling.yml
+++ b/.github/workflows/flake-publish-rolling.yml
@@ -1,3 +1,4 @@
+name: "Publish on Flakehub"
 on:
   push:
     branches:
@@ -9,9 +10,14 @@ jobs:
       id-token: "write"
       contents: "read"
     steps:
-      - uses: "actions/checkout@v3"
-      - uses: "DeterminateSystems/nix-installer-action@main"
-      - uses: "DeterminateSystems/flakehub-push@main"
+      - name: Checkout
+        uses: "actions/checkout@v4"
+      - name: Install Nix
+        uses: "DeterminateSystems/nix-installer-action@main"
+      - name: Setup Nix Cache
+        uses: DeterminateSystems/magic-nix-cache-action@main
+      - name: Push to Flakehub
+        uses: "DeterminateSystems/flakehub-push@main"
         with:
           visibility: "public"
           rolling: true

--- a/flake.nix
+++ b/flake.nix
@@ -68,15 +68,15 @@
         commands = [
           {
             package = pkgs.alejandra;
-            help = "Format nix code";
-          }
-          {
-            package = pkgs.statix;
-            help = "Lint nix code";
+            category = "formatters";
           }
           {
             package = pkgs.deadnix;
-            help = "Find unused expressions in nix code";
+            category = "linters";
+          }
+          {
+            package = pkgs.statix;
+            category = "linters";
           }
         ];
 


### PR DESCRIPTION
- Enhances devshell configuration and extracts it to `shell.nix`
- Removes dependency on flake-utils to reduce download size
- Removes pre-commit hooks because they do not guarantee style enforcement. reduces download size too.
- Adds treefmt-nix that unifies `nix fmt` and `nix flake check` and allows to use multiple formatters and linters with `nix fmt` at once.
- Adds a github action that runs `nix flake check` on every pull request to ensure consistent styling, and perform all other checks defined in the flake should they be added in the future.


*In my opinion nixfmt-rfc-style is better than alejandra because alejandra makes nix code look confusing, to switch to nixfmt just replace `alejandra.enable` with `nixfmt.enable` in `treefmt.nix` and execute `nix fmt`. You might also want to enable more formatters to format non-nix nix-topology code with `nix fmt` by adding `prettier.enable` or `yamlfmt.enable` to `treefmt.nix` for full list of supported formatters check [treefmt-nix](https://github.com/numtide/treefmt-nix)*