### PR TITLE
feat(docs): link to github rather then the nix store

### DIFF
--- a/pkgs/docs.nix
+++ b/pkgs/docs.nix
@@ -15,6 +15,26 @@
       })
       options
       ;
+    transformOptions = opt:
+      opt
+      // {
+        declarations =
+          map (
+            decl:
+              if lib.hasPrefix (toString ../.) (toString decl)
+              then
+                gitHubDeclaration (
+                  lib.removePrefix "/" (lib.removePrefix (toString ../.) (toString decl))
+                )
+              else decl
+          )
+          opt.declarations;
+      };
+  };
+
+  gitHubDeclaration = subpath: {
+    url = "https://github.com/oddlama/nix-topology/blob/main/${subpath}";
+    name = "<${subpath}>";
   };
 
   flakeForExample = path: let


### PR DESCRIPTION
This makes the docs link to github rather then a location in the nix store, which is a bit nicer when reading the published documentation.

![{BDC88DCE-5F29-4350-AA01-B6F3DE4FE613}](https://github.com/user-attachments/assets/cabd5c5f-3554-4c19-8f80-beb99face149)
