### PR TITLE
fix: samba renamed settings

### DIFF
--- a/nixos/extractors/services.nix
+++ b/nixos/extractors/services.nix
@@ -364,7 +364,7 @@ in {
         name = "Samba";
         icon = "services.samba";
         details.shares = let
-          shares = attrNames config.services.samba.shares;
+          shares = lib.remove "global" (attrNames config.services.samba.settings);
         in
           mkIf (shares != []) {text = concatLines shares;};
       };


### PR DESCRIPTION
Samba shares have been renamed to settings. Since these are the unified settings, they also include global settings
defined under the keyword `global`, since that isn't a share I choose to specifically exclude it.
