### PR TITLE
build: Add treefmt-nix

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,1 @@
-github: ['oddlama']
+github: ["oddlama"]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,12 +23,14 @@ If you want to submit a change, please make sure you have checked the following 
   should reflect that accordingly.
 
   Example: If your PR adds two service extractors, you should also have two commits:
+
   - `feat(extractors/services): Add support for vaultwarden`
   - `feat(extractors/services): Add support for forgejo`
 
   Changes to extractors should be scoped like `feat(extractors/<extractor_name>)`,
   same for `renderers/<renderer_name>` and `options/<option_name>`. If a change
   doesn't fit any of these scopes, then just don't add a scope.
+
 - I'm generally happy to accept any extractor, but please make sure they
   meet the [extractor criteria from the documentation](https://oddlama.github.io/nix-topology/internals/development.html)
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Most of the work is done by the included NixOS module which automatically collec
   - 🖥️ Guests from nixos containers
   - 🌐 Network information from kea
 - 🗺️ Renders both a main diagram (physical connections) and a network-centric diagram
-- ➡️  Automatically propagates assigned networks through your connections
+- ➡️ Automatically propagates assigned networks through your connections
 - 🖨️ Allows you to add external devices like switches, routers, printers ...
 
 Have a look at the [examples](./examples) directory for some self-contained examples
@@ -118,11 +118,11 @@ A [flake-parts](https://flake.parts) module is also available (see end of this s
   });
 }
 ```
+
 </details>
 
 <details>
 <summary>Example flake.nix with flake-parts</summary>
-
 
 ```nix
 {
@@ -144,6 +144,7 @@ A [flake-parts](https://flake.parts) module is also available (see end of this s
     };
 }
 ```
+
 </details>
 
 ## 🌱 Adding connections, networks and other devices

--- a/docs/src/helpers.md
+++ b/docs/src/helpers.md
@@ -48,7 +48,6 @@ It particular, it will:
   other interfaces in that specific list, like a dumb switch would.
 - Accepts an attrset `connections` where you can specify additional connections
   for each interface in the form of a single connection or list of connections.
-``.
 
 Example:
 

--- a/docs/src/installation.md
+++ b/docs/src/installation.md
@@ -82,4 +82,5 @@ defining the global module and adding the NixOS module to your systems:
   });
 }
 ```
+
 </details>

--- a/docs/src/internals/development.md
+++ b/docs/src/internals/development.md
@@ -3,16 +3,16 @@
 First of all, here's a very quick overview over the codebase:
 
 - `examples/` each folder in here should contain a `flake.nix` as a user would write it for their configuration.
-   Each such example flake will automatically be evaluated and rendered in the documentation.
+  Each such example flake will automatically be evaluated and rendered in the documentation.
 - `icons/` contains all the service, device and interface icons. Placing a new file here will automatically register it.
 - `nixos/` contains anything related to the provided NixOS module. Mostly information extractors.
 - `options/` contains shared options. Shared means that all of these options will be present
-   both in the global topology module and also in each NixOS module under the `topology` option,
-   which will be merged into the global topology. If you need NixOS specific options (like extractors) or topology specific options (like renderers)
-   have a look at `nixos/module.nix` and `topology/default.nix`.
+  both in the global topology module and also in each NixOS module under the `topology` option,
+  which will be merged into the global topology. If you need NixOS specific options (like extractors) or topology specific options (like renderers)
+  have a look at `nixos/module.nix` and `topology/default.nix`.
 - `pkgs/` contains our nixpkgs overlay and packages required to render the graphs.
 - `topology/` contains anything related to the global topology module. This is where the NixOS configurations
-   are merged into the global topology and where the renderers are defined.
+  are merged into the global topology and where the renderers are defined.
 
 ## Criteria for new extractors and service extractors
 

--- a/docs/src/intro.md
+++ b/docs/src/intro.md
@@ -15,7 +15,7 @@ Most of the work is done by the included NixOS module which automatically collec
   - 🖥️ Guests from nixos containers
   - 🌐 Network information from kea
 - 🗺️ Renders both a main diagram (physical connections) and a network-centric diagram
-- ➡️  Automatically propagates assigned networks through your connections
+- ➡️ Automatically propagates assigned networks through your connections
 - 🖨️ Allows you to add external devices like switches, routers, printers ...
 
 Have a look at the examples on the left for some finished configurations and inspiration.

--- a/flake.lock
+++ b/flake.lock
@@ -1,41 +1,5 @@
 {
   "nodes": {
-    "devshell": {
-      "inputs": {
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1728330715,
-        "narHash": "sha256-xRJ2nPOXb//u1jaBnDP56M7v5ldavjbtR6lfGqSvcKg=",
-        "owner": "numtide",
-        "repo": "devshell",
-        "rev": "dd6b80932022cea34a019e2bb32f6fa9e494dfef",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "devshell",
-        "type": "github"
-      }
-    },
-    "flake-compat": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1696426674,
-        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
-        "type": "github"
-      },
-      "original": {
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "type": "github"
-      }
-    },
     "flake-utils": {
       "inputs": {
         "systems": "systems"
@@ -51,27 +15,6 @@
       "original": {
         "owner": "numtide",
         "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "gitignore": {
-      "inputs": {
-        "nixpkgs": [
-          "pre-commit-hooks",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1709087332,
-        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
-        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
         "type": "github"
       }
     },
@@ -91,37 +34,11 @@
         "type": "github"
       }
     },
-    "pre-commit-hooks": {
-      "inputs": {
-        "flake-compat": "flake-compat",
-        "gitignore": "gitignore",
-        "nixpkgs": [
-          "nixpkgs"
-        ],
-        "nixpkgs-stable": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1730797577,
-        "narHash": "sha256-SrID5yVpyUfknUTGWgYkTyvdr9J1LxUym4om3SVGPkg=",
-        "owner": "cachix",
-        "repo": "pre-commit-hooks.nix",
-        "rev": "1864030ed24a2b8b4e4d386a5eeaf0c5369e50a9",
-        "type": "github"
-      },
-      "original": {
-        "owner": "cachix",
-        "repo": "pre-commit-hooks.nix",
-        "type": "github"
-      }
-    },
     "root": {
       "inputs": {
-        "devshell": "devshell",
         "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs",
-        "pre-commit-hooks": "pre-commit-hooks"
+        "treefmt-nix": "treefmt-nix"
       }
     },
     "systems": {
@@ -136,6 +53,26 @@
       "original": {
         "owner": "nix-systems",
         "repo": "default",
+        "type": "github"
+      }
+    },
+    "treefmt-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1738070913,
+        "narHash": "sha256-j6jC12vCFsTGDmY2u1H12lMr62fnclNjuCtAdF1a4Nk=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "bebf27d00f7d10ba75332a0541ac43676985dea3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -2,88 +2,61 @@
   description = "🍁 Generate infrastructure and network diagrams directly from your NixOS configurations";
 
   inputs = {
-    devshell = {
-      url = "github:numtide/devshell";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
-
-    flake-utils.url = "github:numtide/flake-utils";
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
 
-    pre-commit-hooks = {
-      url = "github:cachix/pre-commit-hooks.nix";
+    flake-utils.url = "github:numtide/flake-utils";
+
+    treefmt-nix = {
+      url = "github:numtide/treefmt-nix";
       inputs.nixpkgs.follows = "nixpkgs";
-      inputs.nixpkgs-stable.follows = "nixpkgs";
     };
   };
 
   outputs = {
     self,
-    devshell,
     flake-utils,
     nixpkgs,
-    pre-commit-hooks,
+    treefmt-nix,
     ...
   } @ inputs:
     {
       flakeModule = ./flake-module.nix;
 
       # Expose NixOS module
-      nixosModules.topology = ./nixos/module.nix;
-      nixosModules.default = self.nixosModules.topology;
+      nixosModules = rec {
+        default = topology;
+        topology = ./nixos/module.nix;
+      };
 
       # A nixpkgs overlay that adds the parametrized builder as a package
-      overlays.default = self.overlays.topology;
-      overlays.topology = import ./pkgs/default.nix;
+      overlays = rec {
+        default = topology;
+        topology = import ./pkgs/default.nix;
+      };
     }
-    // flake-utils.lib.eachDefaultSystem (system: rec {
-      pkgs = import nixpkgs {
-        inherit system;
-        overlays = [
-          self.overlays.default
-          devshell.overlays.default
-        ];
-      };
-
-      packages.docs = pkgs.callPackage ./pkgs/docs.nix {
-        flakeInputs = inputs;
-        flakeOutputs = self;
-      };
-
-      # `nix flake check`
-      checks.pre-commit-hooks = pre-commit-hooks.lib.${system}.run {
-        src = nixpkgs.lib.cleanSource ./.;
-        hooks = {
-          # Nix
-          alejandra.enable = true;
-          deadnix.enable = true;
-          statix.enable = true;
+    // flake-utils.lib.eachDefaultSystem (
+      system: let
+        pkgs = import nixpkgs {
+          inherit system;
+          overlays = [self.overlays.default];
         };
-      };
+        treefmt = (treefmt-nix.lib.evalModule pkgs ./treefmt.nix).config.build;
+      in {
+        packages.docs = pkgs.callPackage ./pkgs/docs.nix {
+          flakeInputs = inputs;
+          flakeOutputs = self;
+        };
 
-      # `nix develop`
-      devShells.default = pkgs.devshell.mkShell {
-        name = "nix-topology";
+        # `nix fmt`
+        formatter = treefmt.wrapper;
 
-        commands = [
-          {
-            package = pkgs.alejandra;
-            category = "formatters";
-          }
-          {
-            package = pkgs.deadnix;
-            category = "linters";
-          }
-          {
-            package = pkgs.statix;
-            category = "linters";
-          }
-        ];
+        # `nix flake check`
+        checks.formatting = treefmt.check self;
 
-        devshell.startup.pre-commit.text = self.checks.${system}.pre-commit-hooks.shellHook;
-      };
-
-      # `nix fmt`
-      formatter = pkgs.alejandra;
-    });
+        # `nix develop`
+        devShells.default = pkgs.mkShell {
+          packages = [pkgs.mdbook];
+        };
+      }
+    );
 }

--- a/pkgs/elk-to-svg/default.nix
+++ b/pkgs/elk-to-svg/default.nix
@@ -7,7 +7,7 @@ buildNpmPackage {
   version = "1.0.0";
 
   src = ./.;
-  npmDepsHash = "sha256-CAzXbGLgsb02A5ehb7XhT6TEYW1XN6s6g5Rr8Blm8kY=";
+  npmDepsHash = "sha256-EHybxOl+xKXnSFb2TEYqI5ESiIcnSwVWswH4q5pf7F0=";
   dontNpmBuild = true;
 
   #passthru.updateScript = nix-update-script { };

--- a/pkgs/elk-to-svg/main.js
+++ b/pkgs/elk-to-svg/main.js
@@ -1,219 +1,221 @@
 import fs from "node:fs/promises";
-import syncFs from 'node:fs';
+import syncFs from "node:fs";
 import { Command } from "commander";
 import ELK from "elkjs/lib/elk.bundled.js";
-import { optimize } from 'svgo';
-import { parse as parseSvg } from 'svg-parser';
+import { optimize } from "svgo";
+import { parse as parseSvg } from "svg-parser";
 
 const defaultStyles = {
-    background: "#080a0d",
-    nodeShapeStroke: "#444488",
-    nodeShapeFill: "#ddddff",
-    labelStroke: "none",
-    labelFill: "#b6beca",
-    labelFontFamily: "JetBrains Mono",
-    labelFontSize: "12px",
-    edgeStrokeWidth: 2,
-    edgeStroke: "#b6beca",
-    edgeFill: "none",
-    portShapeFill: "#6666cc",
-    portShapeStroke: "#444488",
-    portShapeStrokeWidth: 2,
+  background: "#080a0d",
+  nodeShapeStroke: "#444488",
+  nodeShapeFill: "#ddddff",
+  labelStroke: "none",
+  labelFill: "#b6beca",
+  labelFontFamily: "JetBrains Mono",
+  labelFontSize: "12px",
+  edgeStrokeWidth: 2,
+  edgeStroke: "#b6beca",
+  edgeFill: "none",
+  portShapeFill: "#6666cc",
+  portShapeStroke: "#444488",
+  portShapeStrokeWidth: 2,
 };
 
 function svg(strings, ...values) {
-    let str = '';
-    strings.forEach((s, i) => {
-        str += s + (values[i] || '');
-    });
-    return str;
+  let str = "";
+  strings.forEach((s, i) => {
+    str += s + (values[i] || "");
+  });
+  return str;
 }
 
 function createSvgPath(data, radius) {
-    const {
-        startPoint,
-        endPoint
-    } = data;
-    const bendPoints = data.bendPoints || [];
-    let path = `M ${startPoint.x} ${startPoint.y}`;
+  const { startPoint, endPoint } = data;
+  const bendPoints = data.bendPoints || [];
+  let path = `M ${startPoint.x} ${startPoint.y}`;
 
-    let lx = startPoint.x;
-    let ly = startPoint.y;
+  let lx = startPoint.x;
+  let ly = startPoint.y;
 
-    for (let i = 0; i < bendPoints.length; i++) {
-        const bx = bendPoints[i].x;
-        const by = bendPoints[i].y;
+  for (let i = 0; i < bendPoints.length; i++) {
+    const bx = bendPoints[i].x;
+    const by = bendPoints[i].y;
 
-        if (bendPoints[i].shared == true) {
-            path += ` L ${bx} ${by}`;
-        } else {
-            const next = bendPoints[i + 1] || endPoint;
-            const nx = next.x;
-            const ny = next.y;
+    if (bendPoints[i].shared == true) {
+      path += ` L ${bx} ${by}`;
+    } else {
+      const next = bendPoints[i + 1] || endPoint;
+      const nx = next.x;
+      const ny = next.y;
 
-            // Calculate the lengths of the line segments
-            const d1 = Math.sqrt((bx - lx) ** 2 + (by - ly) ** 2);
-            const d2 = Math.sqrt((nx - bx) ** 2 + (ny - by) ** 2);
+      // Calculate the lengths of the line segments
+      const d1 = Math.sqrt((bx - lx) ** 2 + (by - ly) ** 2);
+      const d2 = Math.sqrt((nx - bx) ** 2 + (ny - by) ** 2);
 
-            // Adjust the maximum radius based on the shortest half-line segment
-            const maxRadius = Math.min(d1, d2) / 2;
-            const adjustedRadius = Math.min(radius, maxRadius);
+      // Adjust the maximum radius based on the shortest half-line segment
+      const maxRadius = Math.min(d1, d2) / 2;
+      const adjustedRadius = Math.min(radius, maxRadius);
 
-            // Calculate intersection points
-            const ix = bx + ((lx - bx) / d1) * adjustedRadius;
-            const iy = by + ((ly - by) / d1) * adjustedRadius;
+      // Calculate intersection points
+      const ix = bx + ((lx - bx) / d1) * adjustedRadius;
+      const iy = by + ((ly - by) / d1) * adjustedRadius;
 
-            const jx = bx + ((nx - bx) / d2) * adjustedRadius;
-            const jy = by + ((ny - by) / d2) * adjustedRadius;
+      const jx = bx + ((nx - bx) / d2) * adjustedRadius;
+      const jy = by + ((ny - by) / d2) * adjustedRadius;
 
-            // Calculate the cross product
-            const crossProduct = (jx - bx) * (iy - by) - (jy - by) * (ix - bx);
+      // Calculate the cross product
+      const crossProduct = (jx - bx) * (iy - by) - (jy - by) * (ix - bx);
 
-            // Append path segment with the correct turn flag
-            path += ` L ${ix} ${iy} A ${adjustedRadius} ${adjustedRadius} 0 0 ${crossProduct >= 0 ? 1 : 0} ${jx} ${jy}`;
-        }
-
-        lx = bx;
-        ly = by;
+      // Append path segment with the correct turn flag
+      path += ` L ${ix} ${iy} A ${adjustedRadius} ${adjustedRadius} 0 0 ${crossProduct >= 0 ? 1 : 0} ${jx} ${jy}`;
     }
 
-    path += ` L ${endPoint.x} ${endPoint.y}`;
+    lx = bx;
+    ly = by;
+  }
 
-    return path;
+  path += ` L ${endPoint.x} ${endPoint.y}`;
+
+  return path;
 }
 
 function isPointOnSegment(A, B, P, radius) {
-    // Project P onto A->B
-    let dX_AB = B.x - A.x;
-    let dY_AB = B.y - A.y;
-    let dX_AP = P.x - A.x;
-    let dY_AP = P.y - A.y;
-    // dot product of (B - A) and (P - A)
-    let dotProduct = dX_AB * dX_AP + dY_AB * dY_AP;
-    let length_AB = Math.sqrt(dX_AB * dX_AB + dY_AB * dY_AB);
-    let projDistance = dotProduct / length_AB;
+  // Project P onto A->B
+  let dX_AB = B.x - A.x;
+  let dY_AB = B.y - A.y;
+  let dX_AP = P.x - A.x;
+  let dY_AP = P.y - A.y;
+  // dot product of (B - A) and (P - A)
+  let dotProduct = dX_AB * dX_AP + dY_AB * dY_AP;
+  let length_AB = Math.sqrt(dX_AB * dX_AB + dY_AB * dY_AB);
+  let projDistance = dotProduct / length_AB;
 
-    // If projected point isn't in the inner segment (including the radius),
-    // then we can already return
-    if (projDistance <= radius || projDistance >= length_AB - radius) {
-        return false;
-    }
+  // If projected point isn't in the inner segment (including the radius),
+  // then we can already return
+  if (projDistance <= radius || projDistance >= length_AB - radius) {
+    return false;
+  }
 
-    // Check whether real point P is at least epsilon-near to P',
-    // calculate distance of P to line
-    let dX_PA = A.x - P.x;
-    let dY_PA = A.y - P.y;
-    let distance = Math.abs(dX_AB * dY_PA - dX_PA * dY_AB) / length_AB;
-    return distance < 0.01;
+  // Check whether real point P is at least epsilon-near to P',
+  // calculate distance of P to line
+  let dX_PA = A.x - P.x;
+  let dY_PA = A.y - P.y;
+  let distance = Math.abs(dX_AB * dY_PA - dX_PA * dY_AB) / length_AB;
+  return distance < 0.01;
 }
 
 function toSvgPaths(edge) {
-    const radius = 5.0;
-    //const lines = [];
+  const radius = 5.0;
+  //const lines = [];
 
-    //// Assuming `sections` is your array of objects
-    //edge.sections.forEach(section => {
-    //  const segmentPoints = [section.startPoint, ...(section.bendPoints || []), section.endPoint];
-    //  // Create lines for each adjacent pair of points
-    //  for (let i = 0; i < segmentPoints.length - 1; i++) {
-    //    lines.push([segmentPoints[i], segmentPoints[i + 1]]);
-    //  }
-    //});
+  //// Assuming `sections` is your array of objects
+  //edge.sections.forEach(section => {
+  //  const segmentPoints = [section.startPoint, ...(section.bendPoints || []), section.endPoint];
+  //  // Create lines for each adjacent pair of points
+  //  for (let i = 0; i < segmentPoints.length - 1; i++) {
+  //    lines.push([segmentPoints[i], segmentPoints[i + 1]]);
+  //  }
+  //});
 
-    //edge.sections.forEach(section => {
-    //  if (section.bendPoints) {
-    //    section.bendPoints.forEach(bendPoint => {
-    //      bendPoint.shared = false; // Initialize shared property
-    //      for (const line of lines) {
-    //        if (isPointOnSegment(line[0], line[1], bendPoint, radius)) {
-    //          bendPoint.shared = true;
-    //          break; // No need to check further lines once shared is set to true
-    //        }
-    //      }
-    //    });
-    //  }
-    //});
+  //edge.sections.forEach(section => {
+  //  if (section.bendPoints) {
+  //    section.bendPoints.forEach(bendPoint => {
+  //      bendPoint.shared = false; // Initialize shared property
+  //      for (const line of lines) {
+  //        if (isPointOnSegment(line[0], line[1], bendPoint, radius)) {
+  //          bendPoint.shared = true;
+  //          break; // No need to check further lines once shared is set to true
+  //        }
+  //      }
+  //    });
+  //  }
+  //});
 
-    return (edge.sections || []).map(section => {
-        return createSvgPath(section, radius)
-    })
+  return (edge.sections || []).map((section) => {
+    return createSvgPath(section, radius);
+  });
 }
 
 function objectToString(obj) {
-    return Object.entries(obj)
-        .map(([key, value]) => `${key}="${value}"`)
-        .join(' ');
+  return Object.entries(obj)
+    .map(([key, value]) => `${key}="${value}"`)
+    .join(" ");
 }
 
 function renderGraph(g, options, scaleFactor = 1.0) {
-    // marker-end="url(#edgeShapeMarker)"
-    const edgeShape = (edge_d, edge_path) => {
-		let style = Object.assign({}, edge_d.style);
-		var bg = "";
-		let styleBg = {};
-		styleBg["fill"] = style["fill"]
-		styleBg["stroke-width"] = style["stroke-width"];
-        if (style["background"]) {
-			styleBg["stroke"] = style["background"];
-			delete style["background"];
-			bg = svg`
+  // marker-end="url(#edgeShapeMarker)"
+  const edgeShape = (edge_d, edge_path) => {
+    let style = Object.assign({}, edge_d.style);
+    var bg = "";
+    let styleBg = {};
+    styleBg["fill"] = style["fill"];
+    styleBg["stroke-width"] = style["stroke-width"];
+    if (style["background"]) {
+      styleBg["stroke"] = style["background"];
+      delete style["background"];
+      bg = svg`
 				<path d="${edge_path}" ${objectToString(styleBg)} />
 			`;
-        }
-		return svg`
+    }
+    return svg`
 			${bg}
 			<path d="${edge_path}" ${objectToString(style)} />
 		`;
-	};
+  };
 
-    const edge = edge_d => {
-        if (!edge_d.style) {
-            edge_d.style = {};
-        }
-        if (!edge_d.style["fill"]) {
-            edge_d.style["fill"] = defaultStyles.edgeFill;
-        }
-        if (!edge_d.style["stroke"]) {
-            edge_d.style["stroke"] = defaultStyles.edgeStroke;
-        }
-        if (!edge_d.style["stroke-width"]) {
-            edge_d.style["stroke-width"] = defaultStyles.edgeStrokeWidth;
-        }
-        return svg`
-        <g>${toSvgPaths(edge_d).map(edge_path => edgeShape(edge_d, edge_path)).join(" ")}</g>
-        `
-    };
+  const edge = (edge_d) => {
+    if (!edge_d.style) {
+      edge_d.style = {};
+    }
+    if (!edge_d.style["fill"]) {
+      edge_d.style["fill"] = defaultStyles.edgeFill;
+    }
+    if (!edge_d.style["stroke"]) {
+      edge_d.style["stroke"] = defaultStyles.edgeStroke;
+    }
+    if (!edge_d.style["stroke-width"]) {
+      edge_d.style["stroke-width"] = defaultStyles.edgeStrokeWidth;
+    }
+    return svg`
+        <g>${toSvgPaths(edge_d)
+          .map((edge_path) => edgeShape(edge_d, edge_path))
+          .join(" ")}</g>
+        `;
+  };
 
-    const nodeShape = node_d => {
-        if (node_d.svg) {
-			// Load svg
-			var content = syncFs.readFileSync(node_d.svg.file, {
-				encoding: "utf8"
-			});
-			// strip <svg> tag, only take the inner stuff (chromium is too dumb for it)
-			content = content.substring(content.indexOf('>')+1)
-			content = content.substring(0, content.indexOf('</svg>'))
-			// replace mask names to be globally unique
-			content = content.replaceAll("satori", Buffer.from(node_d.id).toString('base64url'))
+  const nodeShape = (node_d) => {
+    if (node_d.svg) {
+      // Load svg
+      var content = syncFs.readFileSync(node_d.svg.file, {
+        encoding: "utf8",
+      });
+      // strip <svg> tag, only take the inner stuff (chromium is too dumb for it)
+      content = content.substring(content.indexOf(">") + 1);
+      content = content.substring(0, content.indexOf("</svg>"));
+      // replace mask names to be globally unique
+      content = content.replaceAll(
+        "satori",
+        Buffer.from(node_d.id).toString("base64url"),
+      );
 
-            return svg`
+      return svg`
                 <g transform="translate(${node_d.x.toString()} ${node_d.y.toString()})">
                     <g transform="scale(${node_d.svg.scale} ${node_d.svg.scale})">
 						${content}
                     </g>
                 </g>
             `;
-        }
-        if (!node_d.style) {
-            node_d.style = {};
-        }
-        if (!node_d.style["fill"]) {
-            node_d.style["fill"] = defaultStyles.nodeShapeFill;
-        }
-        if (!node_d.style["stroke"]) {
-            node_d.style["stroke"] = defaultStyles.nodeShapeStroke;
-        }
-        return svg`
+    }
+    if (!node_d.style) {
+      node_d.style = {};
+    }
+    if (!node_d.style["fill"]) {
+      node_d.style["fill"] = defaultStyles.nodeShapeFill;
+    }
+    if (!node_d.style["stroke"]) {
+      node_d.style["stroke"] = defaultStyles.nodeShapeStroke;
+    }
+    return svg`
             <rect
                 x="${node_d.x.toString()}"
                 y="${node_d.y.toString()}"
@@ -222,75 +224,77 @@ function renderGraph(g, options, scaleFactor = 1.0) {
                 ${objectToString(node_d.style)}
             />
         `;
-    };
-    const nodeLabel = (node_d, label_d) => {
-        if (!label_d.style) {
-            label_d.style = {};
-        }
-        if (!label_d.style["stroke"]) {
-            label_d.style["stroke"] = defaultStyles.labelStroke;
-        }
-        if (!label_d.style["fill"]) {
-            label_d.style["fill"] = defaultStyles.labelFill;
-        }
-        if (!label_d.style["style"]) {
-            label_d.style["style"] = `font: ${defaultStyles.labelFontSize} ${defaultStyles.labelFontFamily};`;
-        }
-        if (!label_d.style["text-anchor"]) {
-            label_d.style["text-anchor"] = "left";
-        }
-        if (!label_d.style["dominant-baseline"]) {
-            label_d.style["dominant-baseline"] = "hanging";
-        }
-		return svg`
+  };
+  const nodeLabel = (node_d, label_d) => {
+    if (!label_d.style) {
+      label_d.style = {};
+    }
+    if (!label_d.style["stroke"]) {
+      label_d.style["stroke"] = defaultStyles.labelStroke;
+    }
+    if (!label_d.style["fill"]) {
+      label_d.style["fill"] = defaultStyles.labelFill;
+    }
+    if (!label_d.style["style"]) {
+      label_d.style["style"] =
+        `font: ${defaultStyles.labelFontSize} ${defaultStyles.labelFontFamily};`;
+    }
+    if (!label_d.style["text-anchor"]) {
+      label_d.style["text-anchor"] = "left";
+    }
+    if (!label_d.style["dominant-baseline"]) {
+      label_d.style["dominant-baseline"] = "hanging";
+    }
+    return svg`
 			<text
 			x="${node_d.x + label_d.x}"
 			y="${node_d.y + label_d.y}"
 			${objectToString(label_d.style)}>${label_d.text}</text>
-		`
-	};
+		`;
+  };
 
-    const nodePortLabel = (node_d, port_d, label_d) => {
-        if (!label_d.style) {
-            label_d.style = {};
-        }
-        if (!label_d.style["stroke"]) {
-            label_d.style["stroke"] = defaultStyles.labelStroke;
-        }
-        if (!label_d.style["fill"]) {
-            label_d.style["fill"] = defaultStyles.labelFill;
-        }
-        if (!label_d.style["style"]) {
-            label_d.style["style"] = `font: ${defaultStyles.labelFontSize} ${defaultStyles.labelFontFamily};`;
-        }
-        if (!label_d.style["text-anchor"]) {
-            label_d.style["text-anchor"] = "left";
-        }
-        if (!label_d.style["dominant-baseline"]) {
-            label_d.style["dominant-baseline"] = "hanging";
-        }
-		return svg`
+  const nodePortLabel = (node_d, port_d, label_d) => {
+    if (!label_d.style) {
+      label_d.style = {};
+    }
+    if (!label_d.style["stroke"]) {
+      label_d.style["stroke"] = defaultStyles.labelStroke;
+    }
+    if (!label_d.style["fill"]) {
+      label_d.style["fill"] = defaultStyles.labelFill;
+    }
+    if (!label_d.style["style"]) {
+      label_d.style["style"] =
+        `font: ${defaultStyles.labelFontSize} ${defaultStyles.labelFontFamily};`;
+    }
+    if (!label_d.style["text-anchor"]) {
+      label_d.style["text-anchor"] = "left";
+    }
+    if (!label_d.style["dominant-baseline"]) {
+      label_d.style["dominant-baseline"] = "hanging";
+    }
+    return svg`
 			<text
 			x="${node_d.x + port_d.x + label_d.x}"
 			y="${node_d.y + port_d.y + label_d.y}"
 			${objectToString(label_d.style)}>${label_d.text}</text>
-		`
-	}
+		`;
+  };
 
-    const nodePort = (node_d, port_d) => {
-        if (!port_d.style) {
-            port_d.style = {};
-        }
-        if (!port_d.style["fill"]) {
-            port_d.style["fill"] = defaultStyles.portShapeFill;
-        }
-        if (!port_d.style["stroke"]) {
-            port_d.style["stroke"] = defaultStyles.portShapeStroke;
-        }
-        if (!port_d.style["stroke-width"]) {
-            port_d.style["stroke-width"] = defaultStyles.portShapeStrokeWidth;
-        }
-		return svg`
+  const nodePort = (node_d, port_d) => {
+    if (!port_d.style) {
+      port_d.style = {};
+    }
+    if (!port_d.style["fill"]) {
+      port_d.style["fill"] = defaultStyles.portShapeFill;
+    }
+    if (!port_d.style["stroke"]) {
+      port_d.style["stroke"] = defaultStyles.portShapeStroke;
+    }
+    if (!port_d.style["stroke-width"]) {
+      port_d.style["stroke-width"] = defaultStyles.portShapeStrokeWidth;
+    }
+    return svg`
     <rect
       x="${node_d.x + port_d.x}"
       y="${node_d.y + port_d.y}"
@@ -298,20 +302,21 @@ function renderGraph(g, options, scaleFactor = 1.0) {
       height="${port_d.height}"
       ${objectToString(port_d.style)}
     />
-    ${port_d.labels && port_d.labels.map(label_d => nodePortLabel(node_d, port_d, label_d)).join(" ")}
-  `}
-    const node = (node_d, parent_d) => svg`
+    ${port_d.labels && port_d.labels.map((label_d) => nodePortLabel(node_d, port_d, label_d)).join(" ")}
+  `;
+  };
+  const node = (node_d, parent_d) => svg`
     <g transform="translate(${parent_d.x.toString()} ${parent_d.y.toString()})">
       <g>${nodeShape(node_d)}</g>
-      <g>${node_d.labels && node_d.labels.map(label_d => nodeLabel(node_d, label_d)).join(" ")}</g>
-      <g>${node_d.ports && node_d.ports.map(port_d => nodePort(node_d, port_d)).join(" ")}</g>
-      <g>${node_d.children && node_d.children.map(_node_d => node(_node_d, node_d)).join(" ")}</g>
+      <g>${node_d.labels && node_d.labels.map((label_d) => nodeLabel(node_d, label_d)).join(" ")}</g>
+      <g>${node_d.ports && node_d.ports.map((port_d) => nodePort(node_d, port_d)).join(" ")}</g>
+      <g>${node_d.children && node_d.children.map((_node_d) => node(_node_d, node_d)).join(" ")}</g>
       <g transform="translate(${node_d.x.toString()} ${node_d.y.toString()})">
-        ${node_d.edges && node_d.edges.map(edge_d => edge(edge_d)).join(" ")}
+        ${node_d.edges && node_d.edges.map((edge_d) => edge(edge_d)).join(" ")}
       </g>
     </g>
-  `
-    const diagram = svg`
+  `;
+  const diagram = svg`
     <svg xmlns="http://www.w3.org/2000/svg"
       viewBox="${g.x.toString()} ${g.y.toString()} ${g.width} ${g.height}"
       width="${g.width * scaleFactor}"
@@ -346,19 +351,19 @@ function renderGraph(g, options, scaleFactor = 1.0) {
         </marker>
       </defs>
       <rect width="${g.width.toString()}" height="${g.height.toString()}" fill="${defaultStyles.background}"/>
-      <g>${g.children.map(node_d => node(node_d, g)).join(" ")}</g>
-      <g>${g.edges && g.edges.map(edge_d => edge(edge_d)).join(" ")}</g>
+      <g>${g.children.map((node_d) => node(node_d, g)).join(" ")}</g>
+      <g>${g.edges && g.edges.map((edge_d) => edge(edge_d)).join(" ")}</g>
     </svg>
-   `
+   `;
 
-    return diagram;
+  return diagram;
 }
 
 function mergeEdges(edges) {
   const mergedEdges = [];
 
   function cleanEdge(obj) {
-	const newObj = Object.assign({}, obj);
+    const newObj = Object.assign({}, obj);
     delete newObj["id"];
     delete newObj["sources"];
     delete newObj["targets"];
@@ -367,31 +372,36 @@ function mergeEdges(edges) {
 
   // Helper function to check if two arrays have common elements
   function haveCommonElements(arr1, arr2) {
-    return arr1.some(item => arr2.includes(item));
+    return arr1.some((item) => arr2.includes(item));
   }
 
   // Iterate through each edge
-  edges.forEach(edge => {
+  edges.forEach((edge) => {
     let merged = false;
 
     // Check if this edge shares sources or targets with any existing merged edge
-	mergedEdges.forEach(mergedEdge => {
+    mergedEdges.forEach((mergedEdge) => {
       if (
-        JSON.stringify(cleanEdge(edge)) === JSON.stringify(cleanEdge(mergedEdge)) &&
+        JSON.stringify(cleanEdge(edge)) ===
+          JSON.stringify(cleanEdge(mergedEdge)) &&
         (haveCommonElements(edge.sources, mergedEdge.sources) ||
           haveCommonElements(edge.targets, mergedEdge.targets))
       ) {
-		// Merge sources and targets
-        mergedEdge.sources = [...new Set([...edge.sources, ...mergedEdge.sources])];
-        mergedEdge.targets = [...new Set([...edge.targets, ...mergedEdge.targets])];
+        // Merge sources and targets
+        mergedEdge.sources = [
+          ...new Set([...edge.sources, ...mergedEdge.sources]),
+        ];
+        mergedEdge.targets = [
+          ...new Set([...edge.targets, ...mergedEdge.targets]),
+        ];
         merged = true;
         return;
       }
     });
 
-	// If no merge occurred, add the edge as is
+    // If no merge occurred, add the edge as is
     if (!merged) {
-	  mergedEdges.push({ ...edge });
+      mergedEdges.push({ ...edge });
     }
   });
 
@@ -401,96 +411,103 @@ function mergeEdges(edges) {
 const program = new Command();
 
 program
-    .name("elk-to-svg")
-    .description("Convert ELK to SVG")
-    .version("1.0.0")
-    .argument("<input>", "ELK json graph")
-    .argument("<output>", "output svg")
-	.option("--font <font>", "Sets the font")
-	.option("--font-bold <font>", "Sets the bold font")
-    .action(async (input, output, options) => {
-        const elk = new ELK()
-        const graph = JSON.parse(await fs.readFile(input, {
-            encoding: "utf8"
-        }));
+  .name("elk-to-svg")
+  .description("Convert ELK to SVG")
+  .version("1.0.0")
+  .argument("<input>", "ELK json graph")
+  .argument("<output>", "output svg")
+  .option("--font <font>", "Sets the font")
+  .option("--font-bold <font>", "Sets the bold font")
+  .action(async (input, output, options) => {
+    const elk = new ELK();
+    const graph = JSON.parse(
+      await fs.readFile(input, {
+        encoding: "utf8",
+      }),
+    );
 
-        const preprocessNode = node => {
-            if (node.svg) {
-                // Load svg
-                let content = syncFs.readFileSync(node.svg.file, {
-                    encoding: "utf8"
-                });
-
-                // Fill in width and height based on node images
-                let svgContent = parseSvg(content).children.find((x, _1, _2) => x.tagName == "svg" && x.type == "element");
-                let viewBox = svgContent.properties.viewBox.split(" ").map(x => parseInt(x, 10))
-
-                node.svg.width = svgContent.properties.width || (viewBox[2] - viewBox[0]);
-                node.svg.height = svgContent.properties.height || (viewBox[3] - viewBox[1]);
-
-                if (!node.width || node.width == 0) {
-                    node.width = node.svg.width;
-                }
-                if (!node.height || node.height == 0) {
-                    node.height = node.svg.height;
-                }
-
-                if (node.svg.scale) {
-                    node.width = node.width * node.svg.scale;
-                    node.height = node.height * node.svg.scale;
-                } else {
-                    node.svg.scale = 1.0;
-                }
-
-                if (!node.properties) {
-                    node.properties = {};
-                }
-                node.properties["nodeSize.minimum"] = `(${node.width},${node.height})`;
-                node.properties["nodeSize.constraints"] = "[MINIMUM_SIZE]";
-            }
-
-            if (node.children) {
-                node.children.forEach(preprocessNode);
-            }
-        };
-
-        graph.children.forEach(preprocessNode);
-		//var mergedEdges = mergeEdges(graph.edges);
-
-        //console.log(JSON.stringify(graph));
-        const layoutedGraph = await elk.layout(graph).catch(function(e) {
-            console.error(e)
-            process.exit(1);
+    const preprocessNode = (node) => {
+      if (node.svg) {
+        // Load svg
+        let content = syncFs.readFileSync(node.svg.file, {
+          encoding: "utf8",
         });
 
-		// Move edges to the node containing them, so we can render them with the correct offset later
-		const acquireEdges = node => {
-			if (!node.edges) {
-				node.edges = [];
-			}
-			graph.edges = (graph.edges || []).filter(edge => {
-				if (edge.container === node.id) {
-					node.edges.push(edge);
-					return false;
-				}
-				return true;
-			});
-		};
+        // Fill in width and height based on node images
+        let svgContent = parseSvg(content).children.find(
+          (x, _1, _2) => x.tagName == "svg" && x.type == "element",
+        );
+        let viewBox = svgContent.properties.viewBox
+          .split(" ")
+          .map((x) => parseInt(x, 10));
 
-		const acquireEdgesRecursive = node => {
-			acquireEdges(node);
-			if (node.children) {
-				node.children.forEach(acquireEdgesRecursive);
-			}
-		};
+        node.svg.width = svgContent.properties.width || viewBox[2] - viewBox[0];
+        node.svg.height =
+          svgContent.properties.height || viewBox[3] - viewBox[1];
 
-		graph.children.forEach(acquireEdgesRecursive);
+        if (!node.width || node.width == 0) {
+          node.width = node.svg.width;
+        }
+        if (!node.height || node.height == 0) {
+          node.height = node.svg.height;
+        }
 
-        //console.log(JSON.stringify(layoutedGraph));
+        if (node.svg.scale) {
+          node.width = node.width * node.svg.scale;
+          node.height = node.height * node.svg.scale;
+        } else {
+          node.svg.scale = 1.0;
+        }
 
-        const svg = await renderGraph(layoutedGraph, options, 1.0);
-        const svgOpt = optimize(svg, { multipass: true }).data;
-        await fs.writeFile(output, svgOpt);
+        if (!node.properties) {
+          node.properties = {};
+        }
+        node.properties["nodeSize.minimum"] = `(${node.width},${node.height})`;
+        node.properties["nodeSize.constraints"] = "[MINIMUM_SIZE]";
+      }
+
+      if (node.children) {
+        node.children.forEach(preprocessNode);
+      }
+    };
+
+    graph.children.forEach(preprocessNode);
+    //var mergedEdges = mergeEdges(graph.edges);
+
+    //console.log(JSON.stringify(graph));
+    const layoutedGraph = await elk.layout(graph).catch(function (e) {
+      console.error(e);
+      process.exit(1);
     });
+
+    // Move edges to the node containing them, so we can render them with the correct offset later
+    const acquireEdges = (node) => {
+      if (!node.edges) {
+        node.edges = [];
+      }
+      graph.edges = (graph.edges || []).filter((edge) => {
+        if (edge.container === node.id) {
+          node.edges.push(edge);
+          return false;
+        }
+        return true;
+      });
+    };
+
+    const acquireEdgesRecursive = (node) => {
+      acquireEdges(node);
+      if (node.children) {
+        node.children.forEach(acquireEdgesRecursive);
+      }
+    };
+
+    graph.children.forEach(acquireEdgesRecursive);
+
+    //console.log(JSON.stringify(layoutedGraph));
+
+    const svg = await renderGraph(layoutedGraph, options, 1.0);
+    const svgOpt = optimize(svg, { multipass: true }).data;
+    await fs.writeFile(output, svgOpt);
+  });
 
 program.parse();

--- a/pkgs/elk-to-svg/package-lock.json
+++ b/pkgs/elk-to-svg/package-lock.json
@@ -1,244 +1,244 @@
 {
-    "name": "elk-to-svg",
-    "version": "1.0.0",
-    "lockfileVersion": 3,
-    "requires": true,
-    "packages": {
-        "": {
-            "name": "elk-to-svg",
-            "version": "1.0.0",
-            "license": "MIT",
-            "dependencies": {
-                "commander": "^12.0.0",
-                "elkjs": "^0.9.2",
-                "svg-parser": "^2.0.4",
-                "svgo": "^3.2.0"
-            },
-            "bin": {
-                "elk-to-svg": "main.js"
-            }
-        },
-        "node_modules/@trysound/sax": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/@trysound/sax/-/sax-0.2.0.tgz",
-            "integrity": "sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==",
-            "engines": {
-                "node": ">=10.13.0"
-            }
-        },
-        "node_modules/boolbase": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
-            "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="
-        },
-        "node_modules/commander": {
-            "version": "12.0.0",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-12.0.0.tgz",
-            "integrity": "sha512-MwVNWlYjDTtOjX5PiD7o5pK0UrFU/OYgcJfjjK4RaHZETNtjJqrZa9Y9ds88+A+f+d5lv+561eZ+yCKoS3gbAA==",
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/css-select": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.1.0.tgz",
-            "integrity": "sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==",
-            "dependencies": {
-                "boolbase": "^1.0.0",
-                "css-what": "^6.1.0",
-                "domhandler": "^5.0.2",
-                "domutils": "^3.0.1",
-                "nth-check": "^2.0.1"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/fb55"
-            }
-        },
-        "node_modules/css-tree": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.3.1.tgz",
-            "integrity": "sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==",
-            "dependencies": {
-                "mdn-data": "2.0.30",
-                "source-map-js": "^1.0.1"
-            },
-            "engines": {
-                "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
-            }
-        },
-        "node_modules/css-what": {
-            "version": "6.1.0",
-            "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.1.0.tgz",
-            "integrity": "sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==",
-            "engines": {
-                "node": ">= 6"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/fb55"
-            }
-        },
-        "node_modules/csso": {
-            "version": "5.0.5",
-            "resolved": "https://registry.npmjs.org/csso/-/csso-5.0.5.tgz",
-            "integrity": "sha512-0LrrStPOdJj+SPCCrGhzryycLjwcgUSHBtxNA8aIDxf0GLsRh1cKYhB00Gd1lDOS4yGH69+SNn13+TWbVHETFQ==",
-            "dependencies": {
-                "css-tree": "~2.2.0"
-            },
-            "engines": {
-                "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0",
-                "npm": ">=7.0.0"
-            }
-        },
-        "node_modules/csso/node_modules/css-tree": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.2.1.tgz",
-            "integrity": "sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA==",
-            "dependencies": {
-                "mdn-data": "2.0.28",
-                "source-map-js": "^1.0.1"
-            },
-            "engines": {
-                "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0",
-                "npm": ">=7.0.0"
-            }
-        },
-        "node_modules/csso/node_modules/mdn-data": {
-            "version": "2.0.28",
-            "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.28.tgz",
-            "integrity": "sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g=="
-        },
-        "node_modules/dom-serializer": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
-            "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
-            "dependencies": {
-                "domelementtype": "^2.3.0",
-                "domhandler": "^5.0.2",
-                "entities": "^4.2.0"
-            },
-            "funding": {
-                "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
-            }
-        },
-        "node_modules/domelementtype": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
-            "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/fb55"
-                }
-            ]
-        },
-        "node_modules/domhandler": {
-            "version": "5.0.3",
-            "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
-            "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
-            "dependencies": {
-                "domelementtype": "^2.3.0"
-            },
-            "engines": {
-                "node": ">= 4"
-            },
-            "funding": {
-                "url": "https://github.com/fb55/domhandler?sponsor=1"
-            }
-        },
-        "node_modules/domutils": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.1.0.tgz",
-            "integrity": "sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==",
-            "dependencies": {
-                "dom-serializer": "^2.0.0",
-                "domelementtype": "^2.3.0",
-                "domhandler": "^5.0.3"
-            },
-            "funding": {
-                "url": "https://github.com/fb55/domutils?sponsor=1"
-            }
-        },
-        "node_modules/elkjs": {
-            "version": "0.9.2",
-            "resolved": "https://registry.npmjs.org/elkjs/-/elkjs-0.9.2.tgz",
-            "integrity": "sha512-2Y/RaA1pdgSHpY0YG4TYuYCD2wh97CRvu22eLG3Kz0pgQ/6KbIFTxsTnDc4MH/6hFlg2L/9qXrDMG0nMjP63iw=="
-        },
-        "node_modules/entities": {
-            "version": "4.5.0",
-            "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
-            "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
-            "engines": {
-                "node": ">=0.12"
-            },
-            "funding": {
-                "url": "https://github.com/fb55/entities?sponsor=1"
-            }
-        },
-        "node_modules/mdn-data": {
-            "version": "2.0.30",
-            "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.30.tgz",
-            "integrity": "sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA=="
-        },
-        "node_modules/nth-check": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
-            "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
-            "dependencies": {
-                "boolbase": "^1.0.0"
-            },
-            "funding": {
-                "url": "https://github.com/fb55/nth-check?sponsor=1"
-            }
-        },
-        "node_modules/picocolors": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-            "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
-        },
-        "node_modules/source-map-js": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.0.tgz",
-            "integrity": "sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg==",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/svg-parser": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/svg-parser/-/svg-parser-2.0.4.tgz",
-            "integrity": "sha512-e4hG1hRwoOdRb37cIMSgzNsxyzKfayW6VOflrwvR+/bzrkyxY/31WkbgnQpgtrNp1SdpJvpUAGTa/ZoiPNDuRQ=="
-        },
-        "node_modules/svgo": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/svgo/-/svgo-3.2.0.tgz",
-            "integrity": "sha512-4PP6CMW/V7l/GmKRKzsLR8xxjdHTV4IMvhTnpuHwwBazSIlw5W/5SmPjN8Dwyt7lKbSJrRDgp4t9ph0HgChFBQ==",
-            "dependencies": {
-                "@trysound/sax": "0.2.0",
-                "commander": "^7.2.0",
-                "css-select": "^5.1.0",
-                "css-tree": "^2.3.1",
-                "css-what": "^6.1.0",
-                "csso": "^5.0.5",
-                "picocolors": "^1.0.0"
-            },
-            "bin": {
-                "svgo": "bin/svgo"
-            },
-            "engines": {
-                "node": ">=14.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/svgo"
-            }
-        },
-        "node_modules/svgo/node_modules/commander": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
-            "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
-            "engines": {
-                "node": ">= 10"
-            }
+  "name": "elk-to-svg",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "elk-to-svg",
+      "version": "1.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^12.0.0",
+        "elkjs": "^0.9.2",
+        "svg-parser": "^2.0.4",
+        "svgo": "^3.2.0"
+      },
+      "bin": {
+        "elk-to-svg": "main.js"
+      }
+    },
+    "node_modules/@trysound/sax": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@trysound/sax/-/sax-0.2.0.tgz",
+      "integrity": "sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==",
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="
+    },
+    "node_modules/commander": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.0.0.tgz",
+      "integrity": "sha512-MwVNWlYjDTtOjX5PiD7o5pK0UrFU/OYgcJfjjK4RaHZETNtjJqrZa9Y9ds88+A+f+d5lv+561eZ+yCKoS3gbAA==",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/css-select": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.1.0.tgz",
+      "integrity": "sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-tree": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.3.1.tgz",
+      "integrity": "sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==",
+      "dependencies": {
+        "mdn-data": "2.0.30",
+        "source-map-js": "^1.0.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/css-what": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.1.0.tgz",
+      "integrity": "sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==",
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/csso": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/csso/-/csso-5.0.5.tgz",
+      "integrity": "sha512-0LrrStPOdJj+SPCCrGhzryycLjwcgUSHBtxNA8aIDxf0GLsRh1cKYhB00Gd1lDOS4yGH69+SNn13+TWbVHETFQ==",
+      "dependencies": {
+        "css-tree": "~2.2.0"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/csso/node_modules/css-tree": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.2.1.tgz",
+      "integrity": "sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA==",
+      "dependencies": {
+        "mdn-data": "2.0.28",
+        "source-map-js": "^1.0.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/csso/node_modules/mdn-data": {
+      "version": "2.0.28",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.28.tgz",
+      "integrity": "sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g=="
+    },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
         }
+      ]
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.1.0.tgz",
+      "integrity": "sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/elkjs": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/elkjs/-/elkjs-0.9.2.tgz",
+      "integrity": "sha512-2Y/RaA1pdgSHpY0YG4TYuYCD2wh97CRvu22eLG3Kz0pgQ/6KbIFTxsTnDc4MH/6hFlg2L/9qXrDMG0nMjP63iw=="
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.0.30",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.30.tgz",
+      "integrity": "sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA=="
+    },
+    "node_modules/nth-check": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+      "dependencies": {
+        "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
+      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.0.tgz",
+      "integrity": "sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/svg-parser": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/svg-parser/-/svg-parser-2.0.4.tgz",
+      "integrity": "sha512-e4hG1hRwoOdRb37cIMSgzNsxyzKfayW6VOflrwvR+/bzrkyxY/31WkbgnQpgtrNp1SdpJvpUAGTa/ZoiPNDuRQ=="
+    },
+    "node_modules/svgo": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/svgo/-/svgo-3.2.0.tgz",
+      "integrity": "sha512-4PP6CMW/V7l/GmKRKzsLR8xxjdHTV4IMvhTnpuHwwBazSIlw5W/5SmPjN8Dwyt7lKbSJrRDgp4t9ph0HgChFBQ==",
+      "dependencies": {
+        "@trysound/sax": "0.2.0",
+        "commander": "^7.2.0",
+        "css-select": "^5.1.0",
+        "css-tree": "^2.3.1",
+        "css-what": "^6.1.0",
+        "csso": "^5.0.5",
+        "picocolors": "^1.0.0"
+      },
+      "bin": {
+        "svgo": "bin/svgo"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/svgo"
+      }
+    },
+    "node_modules/svgo/node_modules/commander": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "engines": {
+        "node": ">= 10"
+      }
     }
+  }
 }

--- a/pkgs/elk-to-svg/package.json
+++ b/pkgs/elk-to-svg/package.json
@@ -1,18 +1,18 @@
 {
-    "name": "elk-to-svg",
-    "version": "1.0.0",
-    "description": "Converts ELK json descriptions to SVG",
-    "main": "main.js",
-    "author": "oddlama <oddlama@oddlama.org>",
-    "license": "MIT",
-    "type": "module",
-    "bin": {
-        "elk-to-svg": "./main.js"
-    },
-    "dependencies": {
-        "commander": "^12.0.0",
-        "elkjs": "^0.9.2",
-        "svg-parser": "^2.0.4",
-        "svgo": "^3.2.0"
-    }
+  "name": "elk-to-svg",
+  "version": "1.0.0",
+  "description": "Converts ELK json descriptions to SVG",
+  "main": "main.js",
+  "author": "oddlama <oddlama@oddlama.org>",
+  "license": "MIT",
+  "type": "module",
+  "bin": {
+    "elk-to-svg": "./main.js"
+  },
+  "dependencies": {
+    "commander": "^12.0.0",
+    "elkjs": "^0.9.2",
+    "svg-parser": "^2.0.4",
+    "svgo": "^3.2.0"
+  }
 }

--- a/pkgs/html-to-svg/main.js
+++ b/pkgs/html-to-svg/main.js
@@ -14,8 +14,16 @@ program
   .option("--font <font>", "Sets the font")
   .option("--font-bold <font>", "Sets the bold font")
   .option("--embed-font", "If given, will embed the font into the svg")
-  .option("-w, --width <width>", "Sets the width of the output. Use auto for automatic scaling.", "auto")
-  .option("-h, --height <height>", "Sets the height of the output. Use auto for automatic scaling.", "auto")
+  .option(
+    "-w, --width <width>",
+    "Sets the width of the output. Use auto for automatic scaling.",
+    "auto",
+  )
+  .option(
+    "-h, --height <height>",
+    "Sets the height of the output. Use auto for automatic scaling.",
+    "auto",
+  )
   .action(async (input, output, options) => {
     if (!options.font) {
       console.error("--font is required");
@@ -29,8 +37,8 @@ program
 
     const markup = html(await fs.readFile(input, { encoding: "utf8" }));
     const svg = await satori(markup, {
-      ...(options.width != "auto" && {width: options.width}),
-      ...(options.height != "auto" && {height: options.height}),
+      ...(options.width != "auto" && { width: options.width }),
+      ...(options.height != "auto" && { height: options.height }),
       embedFont: options.embedFont == true,
       fonts: [
         {

--- a/statix.toml
+++ b/statix.toml
@@ -1,3 +1,1 @@
-disabled = [
-	"repeated_keys"
-]
+disabled = ["repeated_keys"]

--- a/treefmt.nix
+++ b/treefmt.nix
@@ -1,0 +1,17 @@
+{
+  projectRootFile = "flake.nix";
+
+  settings.global.excludes = ["*.svg"];
+
+  programs = {
+    alejandra.enable = true;
+    deadnix.enable = true;
+    statix.enable = true;
+    prettier.enable = true;
+
+    shfmt.enable = true;
+
+    taplo.enable = true;
+    toml-sort.enable = true;
+  };
+}


### PR DESCRIPTION
This PR removes pre-commit checks and delegates those to the CI when the treefmt checks are run by [check-flake.yml](https://github.com/oddlama/nix-topology/blob/main/.github/workflows/check-flake.yml).

Numtide dev shells have been removed too as they are replaced by just using `nix fmt`, reducing the flake size.
_Standard_ dev shells are taking their place instead with the [mdbook](https://search.nixos.org/packages?channel=unstable&query=mdbook) package, which I've found was missing when I tried to serve the documentation locally.

The formatter is left to be Alejandra. However, it would be beneficial to change to `nixfmt-rfc-style` ([nixfmt](https://github.com/numtide/treefmt-nix/blob/main/programs/nixfmt.nix) in treefmt-nix) in order to guarantee the same styling as in Nixpkgs.