### PR TITLE
Fixes and customises address list formatting for interfaces

### DIFF
--- a/options/interfaces.nix
+++ b/options/interfaces.nix
@@ -268,6 +268,12 @@ in
                   type = types.listOf types.str;
                 };
 
+                addressFormatter = mkOption {
+                  description = "A function to format a list of addresses.";
+                  default = lib.concatStringsSep "\n";
+                  type = types.functionTo types.str;
+                };
+
                 gateways = mkOption {
                   description = "The configured gateways, if any.";
                   default = [];

--- a/topology/renderers/elk/lib.nix
+++ b/topology/renderers/elk/lib.nix
@@ -119,7 +119,7 @@ in rec {
       "50-mac" = mkLabel interface.mac 1 netStyle;
     }
     // optionalAttrs (interface.addresses != []) {
-      "60-addrs" = mkLabel (toString interface.addresses) 1 netStyle;
+      "60-addrs" = mkLabel (interface.addressFormatter interface.addresses) 1 netStyle;
     };
 
   mkDiagram = defs:


### PR DESCRIPTION
Adds a formatting function, which defaults to just `lib.concatStringsSep "\n"`, to make the labels for interface addresses.