### PR TITLE
fix(flake-module): Added filtering for supported system

### DIFF
--- a/flake-module.nix
+++ b/flake-module.nix
@@ -50,8 +50,8 @@ in {
         nixosConfigurations = mkOption {
           type = types.lazyAttrsOf types.unspecified;
           description = "All nixosSystems that should be evaluated for topology definitions.";
-          default = self.nixosConfigurations;
-          defaultText = lib.literalExpression "self.nixosConfigurations";
+          default = lib.filterAttrs (_: x: x.config ? topology) self.nixosConfigurations;
+          defaultText = lib.literalExpression "lib.filterAttrs (_: x: x.config ? topology) self.nixosConfigurations";
         };
         pkgs = mkOption {
           type = types.unspecified;


### PR DESCRIPTION
Added a filter to the default `nixosConfigurations` list option that checks if the given configuration contains a `topology` module.