### PR TITLE
fix: add default value to dependentConfigurations

### DIFF
--- a/nixos/module.nix
+++ b/nixos/module.nix
@@ -62,6 +62,7 @@ in {
         A list of option definition values that shall be merged with this host's definitions.
         Useful to bring in dependent configurations like nixos-containers or vm configs.
       '';
+      default = [];
       type = types.listOf types.unspecified;
     };
 


### PR DESCRIPTION
If you disable microvm and nixos-containers extractors evaluation will fail with
`error: The option 'topology.dependentConfigurations' was accessed but has no value defined. Try setting the option.`

This PR addresses the issue by setting default value for the option. It will be later overriden by microvm/nixos-containers module if those are enabled.

Steps to reproduce:
1. Disable mentioned extractors in configuration, e.g.:
```nix
topology.extractors.microvm.enable = false;
topology.extractors.nixos-container.enable = false;
```
2. Try to evaluate the configuration