### PR TITLE
Check class of topology modules

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -3,9 +3,10 @@
   pkgs ? import <nixpkgs> {},
   modules ? [],
   specialArgs ? {},
+  class ? "topology",
 }:
 pkgs.lib.evalModules {
-  inherit prefix;
+  inherit class prefix;
   modules = [./topology] ++ modules;
   specialArgs =
     {


### PR DESCRIPTION
## Motivation for this change

Users that are enough into NixOS to use nix-topology are likely users of other libraries such as disko, dns.nix, flake-parts and so on. It's easy to mix-and-match modules made for different evaluations and end up with `The option topology.something does not exist`.

Adding the class check to `evalModules` allows user to explicitly mark the module as part of their topology and results in a clear error `The module cannot be imported into a module evaluation that expects class "topology"`

## Other solutions

Doing nothing about it is a possibility, most of the times the option name is "unique enough" to understand the error. `nodes` though is a valid option for both nix-topology and nixosTest, for example.

