### PR TITLE
extractors/kea: support multiple subnets and dhcp6

### DIFF
--- a/nixos/extractors/kea.nix
+++ b/nixos/extractors/kea.nix
@@ -5,32 +5,54 @@
 }: let
   inherit
     (lib)
-    const
     filter
-    genAttrs
     hasInfix
+    imap1
+    length
+    listToAttrs
     mkEnableOption
     mkIf
+    mkMerge
+    nameValuePair
+    optionalString
     ;
 in {
   options.topology.extractors.kea.enable = mkEnableOption "topology kea extractor" // {default = true;};
 
   config = let
-    interfaces = filter (x: !hasInfix "*" x) config.services.kea.dhcp4.settings.interfaces-config.interfaces or [];
-    headOrNull = xs:
-      if xs == []
-      then null
-      else builtins.head xs;
-    subnet = headOrNull (map (x: x.subnet) (config.services.kea.dhcp4.settings.subnet4 or []));
-    netName = "${config.topology.self.id}-kea";
+    mkNetworks = version: let
+      kea = config.services.kea."dhcp${version}";
+      interfaces = filter (x: !hasInfix "*" x) (kea.settings.interfaces-config.interfaces or []);
+      subnets = imap1 (idx: subnet: subnet // {_topologyId = subnet.id or idx;}) (kea.settings."subnet${version}" or []);
+    in
+      listToAttrs (map
+        (
+          subnet:
+            nameValuePair "${config.topology.self.id}-kea${optionalString (length subnets > 1) "-${toString subnet._topologyId}"}" {
+              "cidrv${version}" = mkIf (kea.enable && interfaces != [] && subnet.subnet != null) subnet.subnet;
+            }
+        )
+        subnets);
+
+    mkInterfaces = version: let
+      subnets =
+        imap1 (idx: subnet: subnet // {_topologyId = subnet.id or idx;})
+        (config.services.kea."dhcp${version}".settings."subnet${version}" or []);
+    in
+      listToAttrs (map
+        (
+          subnet:
+            nameValuePair "${subnet.interface}" {
+              network = "${config.topology.self.id}-kea${optionalString (length subnets > 1) "-${toString subnet._topologyId}"}";
+            }
+        )
+        subnets);
   in
-    mkIf (config.topology.extractors.kea.enable && config.services.kea.dhcp4.enable && interfaces != [] && subnet != null) {
-      topology.networks.${netName} = {
-        cidrv4 = subnet;
-      };
+    mkIf config.topology.extractors.kea.enable {
+      topology.networks = mkMerge (map mkNetworks ["4" "6"]);
 
       # Do not use topology.self.interfaces here to prevent inclusion of a mkMerge which cannot be
       # detected by the network propagator currently.
-      topology.nodes.${config.topology.id}.interfaces = genAttrs interfaces (const {network = netName;});
+      topology.nodes.${config.topology.id}.interfaces = mkMerge (map mkInterfaces ["4" "6"]);
     };
 }


### PR DESCRIPTION
Currently, the kea renderer only support dhcp4. Also, at the moment only the first subnet under `config.services.kea.dhcp4.settings.subnet4` will be rendered under `topology.networks`.

This enables support for the dhcp6 server and renders a network for each subnet. To go along with this, the interface network assignment was changed to instead fetch its network from the respective subnet where it is set as an interface.

Concerning network naming - as long as kea is configured for only one subnet, the naming scheme will stay the same as before (`<nodeName>-kea`). If there are more than one subnets managed, then the `id` field from the kea subnet will be used. Now, as per [the kea documentation](https://kea.readthedocs.io/en/kea-2.2.0/arm/dhcp4-srv.html) this field is optional, and the id can be set automatically by kea (however, the internal id might change unexpectedly then). For that case, I have opted to apply a crude numbering that roughly resembles the kea numbering, even though manual setting would be preferable in that case.