### PR TITLE
fix(extractor/services): postgres wrong listen

### DIFF
--- a/nixos/extractors/services.nix
+++ b/nixos/extractors/services.nix
@@ -547,7 +547,9 @@ in
       postgresql = mkIf config.services.postgresql.enable {
         name = "PostgreSQL";
         icon = "services.postgresql";
-        details.listen.text = "0.0.0.0:${toString config.services.postgresql.settings.port}";
+        details.listen = mkIf config.services.postgresql.enableTCPIP {
+          text = "0.0.0.0:${toString config.services.postgresql.settings.port}";
+        };
       };
 
       prometheus = mkIf config.services.prometheus.enable {


### PR DESCRIPTION
According to the [docs](https://github.com/NixOS/nixpkgs/blob/e4bae1bd10c9c57b2cf517953ab70060a828ee6f/nixos/modules/services/databases/postgresql.nix#L510) Postgres listens on all interfaces only when this is enabled. Otherwise, Localhost and unix-socket only.