### PR TITLE
fix(renderers/svg): prevent node info bounding box escape

### DIFF
--- a/examples/complex/flake.nix
+++ b/examples/complex/flake.nix
@@ -112,13 +112,13 @@
 
               containers.test.config = {
                 imports = [ nix-topology.nixosModules.default ];
-                networking.hostName = "host2-test";
+                networking.hostName = "host2-test-with-a-long-name";
               };
 
               # We can change our own node's topology settings from here:
               topology.self = {
                 name = "☄️  Powerful host2";
-                hardware.info = "2U Server with loads of RAM";
+                hardware.info = "2U Server with loads of RAM and a really long description";
                 interfaces.wg0 = {
                   addresses = [ "10.0.0.2" ];
                   # Rendering virtual connections such as wireguard connections can sometimes

--- a/topology/renderers/svg/default.nix
+++ b/topology/renderers/svg/default.nix
@@ -231,13 +231,13 @@ let
           html = mkCardContainer /* html */ ''
             <div tw="flex flex-row mx-6 mt-2 items-center">
               ${mkImageMaybe "w-8 h-8 mr-4" (config.lib.icons.get node.icon)}
-              <div tw="flex flex-col min-h-18 justify-center">
+              <div tw="flex flex-col min-h-18 justify-center flex-1 min-w-0">
                 <span tw="text-2xl font-bold">${node.name}</span>
                 ${optionalString (
                   node.hardware.info != null
                 ) ''<span tw="text-xs">${node.hardware.info}</span>''}
               </div>
-              <div tw="flex grow min-w-8"></div>
+              <div tw="flex min-w-8"></div>
               ${mkImageMaybe "w-12 h-12 ml-4" (config.lib.icons.get node.deviceIcon)}
             </div>
 
@@ -263,7 +263,7 @@ let
           mkRootContainer "items-center" /* html */ ''
             <div tw="flex flex-row mx-6 mt-2 items-center">
               ${mkImageMaybe "w-8 h-8 mr-4" (config.lib.icons.get node.icon)}
-              <div tw="flex flex-col min-h-18 justify-center">
+              <div tw="flex flex-col min-h-18 justify-center flex-1 min-w-0">
                 <span tw="text-2xl font-bold">${node.name}</span>
                 ${optionalString (
                   node.hardware.info != null
@@ -272,7 +272,7 @@ let
               ${optionalString
                 (deviceIconImage != null && node.hardware.image != null -> deviceIconImage != node.hardware.image)
                 ''
-                  <div tw="flex grow min-w-4"></div>
+                  <div tw="flex min-w-4"></div>
                   ${mkImageMaybe "w-12 h-12" deviceIconImage}
                 ''
               }


### PR DESCRIPTION
After noting that text sometimes escaped the bounding boxes in #117, I noticed a similar phenomenon for parts of node information, particularly titles and info in conjunction with the icon, which is fixed by this PR.

Previously:
<img width="1975" height="1162" alt="_nix_store_n1cpb266hg4fyxkhsya5q09jr02pmavf-nix-topology-documentation_examples_complex_main svg" src="https://github.com/user-attachments/assets/f27d264c-9771-44e0-9415-a4b93c1ef3bc" />

Now:
<img width="1975" height="1162" alt="_nix_store_pfc7v0f1pgfs10x01hv4w07fig0lpxv4-nix-topology-documentation_examples_complex_main svg" src="https://github.com/user-attachments/assets/8a24d46a-2ed0-4f0a-9f6e-df1e443e0580" />
