### PR TITLE
chore(extractors/services): get rid of obsolescence traces

### DIFF
--- a/nixos/extractors/services.nix
+++ b/nixos/extractors/services.nix
@@ -345,6 +345,7 @@ in
         };
       };
 
+      # TODO: Remove old options when 26.11 is released
       kanidm = mkIf (config.services.kanidm.server.enable or config.services.kanidm.enableServer) {
         name = "Kanidm";
         icon = "services.kanidm";


### PR DESCRIPTION
Kanidm settings got renamed in the unstable branch causing traces of obsolescence.

Should I put in a TODO to remove the old options once we update the lock to 26.05 when it releases?