### PR TITLE
chore(extractors/services): get rid of harmonia obsolescence traces

### DIFF
--- a/nixos/extractors/services.nix
+++ b/nixos/extractors/services.nix
@@ -261,10 +261,8 @@ in
 
       harmonia =
         mkIf
-          (
-            (config.services.harmonia.enable or false)
-            || (config.services.harmonia.cache.enable or false)
-            || (config.services.harmonia-dev.cache.enable or false)
+          (config.services.harmonia.cache.enable or config.services.harmonia-dev.cache.enable
+            or config.services.harmonia.enable or false
           )
           {
             name = "Harmonia";


### PR DESCRIPTION
Before we were evaluating the old option first, causing a lot of traces. With this the newer options are evaluated first.