### PR TITLE
fix: bentopdf backward compat

### DIFF
--- a/nixos/extractors/services.nix
+++ b/nixos/extractors/services.nix
@@ -88,7 +88,7 @@ in
           );
         };
 
-      bentopdf = mkIf config.services.bentopdf.enable {
+      bentopdf = mkIf (config.services.bentopdf.enable or false) {
         name = "BentoPDF";
         icon = "services.bentopdf";
         info = "https://${config.services.bentopdf.domain}";


### PR DESCRIPTION
Fixes eval errors for those running stable NixOS 25.11