### PR TITLE
test: add integration tests for service extraction and SVG rendering

### DIFF
--- a/dev/default.nix
+++ b/dev/default.nix
@@ -12,7 +12,15 @@
       pkgs,
       ...
     }:
+    let
+      inherit (pkgs) lib;
+    in
     {
+      checks = lib.optionalAttrs (lib.hasSuffix "-linux" system) {
+        service-extraction = import ./service-extraction-test.nix { inherit self pkgs system; };
+        svg-render = import ./svg-render-test.nix { inherit self pkgs system; };
+      };
+
       _module.args.pkgs = import inputs.nixpkgs {
         inherit system;
         overlays = [ self.overlays.default ];

--- a/dev/service-extraction-test.nix
+++ b/dev/service-extraction-test.nix
@@ -1,0 +1,167 @@
+{
+  self,
+  pkgs,
+  system,
+}:
+let
+  inherit (pkgs) lib;
+  nixosSystem = import "${pkgs.path}/nixos/lib/eval-config.nix";
+
+  baseModules = [
+    self.nixosModules.topology
+    {
+      networking.hostName = "test-host";
+      fileSystems."/" = {
+        device = "/dev/null";
+        fsType = "ext4";
+      };
+      boot.loader.grub.device = "/dev/null";
+    }
+  ];
+
+  eval = nixosSystem {
+    inherit system;
+    modules = baseModules ++ [
+      {
+        services.grafana = {
+          enable = true;
+          settings.server = {
+            root_url = "https://grafana.example.com";
+            http_addr = "127.0.0.1";
+            http_port = 3000;
+          };
+        };
+
+        services.vaultwarden = {
+          enable = true;
+          config = {
+            domain = "https://vault.example.com";
+            rocketAddress = "0.0.0.0";
+            rocketPort = 8222;
+          };
+        };
+
+        services.prometheus = {
+          enable = true;
+          port = 9090;
+        };
+
+        services.openssh.enable = true;
+      }
+    ];
+  };
+
+  services = builtins.deepSeq eval.config.topology.self.services eval.config.topology.self.services;
+  serviceNames = lib.sort (a: b: a < b) (lib.attrNames services);
+
+  # Evaluate with no services enabled to detect broken/missing `enabled` functions
+  disabledEval = nixosSystem {
+    inherit system;
+    modules = baseModules;
+  };
+  disabledServices =
+    let
+      s = disabledEval.config.topology.self.services;
+    in
+    builtins.deepSeq s s;
+  disabledServiceNames = lib.attrNames (lib.filterAttrs (_: s: s != { }) disabledServices);
+
+  # Build the topology module to verify the full pipeline (services → SVG input)
+  topologyEval = import self {
+    inherit pkgs;
+    modules = [ { nixosConfigurations.test-host = eval; } ];
+  };
+
+  nodesConfig = builtins.deepSeq topologyEval.config.nodes topologyEval.config.nodes;
+  nodeServices = nodesConfig.test-host.services;
+  visibleServices = lib.filterAttrs (_: s: !s.hidden) nodeServices;
+  visibleServiceNames = lib.sort (a: b: a < b) (lib.attrNames visibleServices);
+
+  assertions = [
+    # No services should appear when nothing is enabled (catches missing/broken `enabled` functions)
+    {
+      assertion = disabledServiceNames == [ ];
+      message = "services appeared without being enabled (broken 'enabled' function): ${toString disabledServiceNames}";
+    }
+    {
+      assertion = services ? grafana;
+      message = "expected 'grafana' in extracted services, got: ${toString serviceNames}";
+    }
+    {
+      assertion = services ? vaultwarden;
+      message = "expected 'vaultwarden' in extracted services, got: ${toString serviceNames}";
+    }
+    {
+      assertion = services ? prometheus;
+      message = "expected 'prometheus' in extracted services, got: ${toString serviceNames}";
+    }
+    {
+      assertion = services ? openssh;
+      message = "expected 'openssh' in extracted services, got: ${toString serviceNames}";
+    }
+    {
+      assertion = services.grafana.name == "Grafana";
+      message = "expected grafana name 'Grafana', got '${services.grafana.name}'";
+    }
+    {
+      assertion = services.vaultwarden.name == "Vaultwarden";
+      message = "expected vaultwarden name 'Vaultwarden', got '${services.vaultwarden.name}'";
+    }
+    {
+      assertion = services.grafana.info == "https://grafana.example.com";
+      message = "expected grafana info 'https://grafana.example.com', got '${services.grafana.info}'";
+    }
+    {
+      assertion = services.vaultwarden.info == "https://vault.example.com";
+      message = "expected vaultwarden info 'https://vault.example.com', got '${services.vaultwarden.info}'";
+    }
+    # Verify hidden flag propagation (openssh is hidden by default)
+    {
+      assertion = services.openssh.hidden;
+      message = "expected openssh to be hidden";
+    }
+    {
+      assertion = !services.grafana.hidden;
+      message = "expected grafana to not be hidden";
+    }
+    # Verify topology-level aggregation matches per-host extraction
+    {
+      assertion = visibleServices ? grafana;
+      message = "expected 'grafana' in topology node services, got: ${toString visibleServiceNames}";
+    }
+    {
+      assertion = visibleServices ? vaultwarden;
+      message = "expected 'vaultwarden' in topology node services, got: ${toString visibleServiceNames}";
+    }
+    {
+      assertion = visibleServices ? prometheus;
+      message = "expected 'prometheus' in topology node services, got: ${toString visibleServiceNames}";
+    }
+    {
+      assertion = !(visibleServices ? openssh);
+      message = "expected 'openssh' to NOT be in visible services (it's hidden)";
+    }
+    # Verify the exact set of visible services (catches unexpected additions)
+    {
+      assertion =
+        visibleServiceNames == [
+          "grafana"
+          "prometheus"
+          "vaultwarden"
+        ];
+      message = "expected exactly [grafana prometheus vaultwarden] as visible services, got: ${toString visibleServiceNames}";
+    }
+  ];
+
+  failedAssertions = builtins.filter (a: !a.assertion) assertions;
+  failureMessages = map (a: a.message) failedAssertions;
+in
+if failedAssertions != [ ] then
+  throw "Service extraction test failed:\n${lib.concatStringsSep "\n" failureMessages}"
+else
+  pkgs.runCommandLocal "service-extraction-test" { } ''
+    echo "Service extraction test passed"
+    echo "Extracted services: ${toString serviceNames}"
+    echo "Visible services in topology: ${toString visibleServiceNames}"
+    echo "ok" > $out
+  ''

--- a/dev/svg-render-test.nix
+++ b/dev/svg-render-test.nix
@@ -1,0 +1,82 @@
+{
+  self,
+  pkgs,
+  system,
+}:
+let
+  nixosSystem = import "${pkgs.path}/nixos/lib/eval-config.nix";
+
+  eval = nixosSystem {
+    inherit system;
+    modules = [
+      self.nixosModules.topology
+      {
+        networking.hostName = "svg-test-host";
+        fileSystems."/" = {
+          device = "/dev/null";
+          fsType = "ext4";
+        };
+        boot.loader.grub.device = "/dev/null";
+
+        services.grafana = {
+          enable = true;
+          settings.server = {
+            root_url = "https://grafana.example.com";
+            http_addr = "127.0.0.1";
+            http_port = 3000;
+          };
+        };
+
+        services.prometheus = {
+          enable = true;
+          port = 9090;
+        };
+      }
+    ];
+  };
+
+  topologyEval = import self {
+    inherit pkgs;
+    modules = [ { nixosConfigurations.svg-test-host = eval; } ];
+  };
+
+  elkOutput = topologyEval.config.renderers.elk.output;
+  svgOutput = topologyEval.config.renderers.svg.output;
+in
+pkgs.runCommandLocal "svg-render-test" { nativeBuildInputs = with pkgs; [ libxml2 ]; } ''
+  echo "=== SVG Render Integration Test ==="
+
+  # --- ELK renderer output ---
+  echo "Checking ELK renderer output structure..."
+  test -f "${elkOutput}/main.svg" || (echo "FAIL: main.svg missing"; exit 1)
+  test -f "${elkOutput}/network.svg" || (echo "FAIL: network.svg missing"; exit 1)
+
+  echo "Validating main.svg is well-formed XML..."
+  xmllint --noout "${elkOutput}/main.svg"
+  echo "Validating network.svg is well-formed XML..."
+  xmllint --noout "${elkOutput}/network.svg"
+
+  echo "Checking main.svg contains expected service names..."
+  grep -q "Grafana" "${elkOutput}/main.svg" || (echo "FAIL: 'Grafana' not found in main.svg"; exit 1)
+  grep -q "Prometheus" "${elkOutput}/main.svg" || (echo "FAIL: 'Prometheus' not found in main.svg"; exit 1)
+  grep -q "grafana.example.com" "${elkOutput}/main.svg" || (echo "FAIL: 'grafana.example.com' not found in main.svg"; exit 1)
+
+  echo "Checking main.svg has SVG root element..."
+  grep -q '<svg' "${elkOutput}/main.svg" || (echo "FAIL: no <svg> root element in main.svg"; exit 1)
+
+  # --- Per-node SVG renderer output ---
+  echo "Checking per-node SVG output..."
+  test -d "${svgOutput}/nodes" || (echo "FAIL: nodes/ directory missing from SVG output"; exit 1)
+  test -f "${svgOutput}/nodes/svg-test-host.svg" || (echo "FAIL: svg-test-host.svg missing"; exit 1)
+
+  echo "Validating per-node SVG is well-formed XML..."
+  xmllint --noout "${svgOutput}/nodes/svg-test-host.svg"
+
+  echo "Checking per-node SVG contains expected content..."
+  grep -q "Grafana" "${svgOutput}/nodes/svg-test-host.svg" || (echo "FAIL: 'Grafana' not found in node SVG"; exit 1)
+  grep -q "Prometheus" "${svgOutput}/nodes/svg-test-host.svg" || (echo "FAIL: 'Prometheus' not found in node SVG"; exit 1)
+  grep -q "grafana.example.com" "${svgOutput}/nodes/svg-test-host.svg" || (echo "FAIL: 'grafana.example.com' not found in node SVG"; exit 1)
+
+  echo "=== All SVG render tests passed ==="
+  echo "ok" > $out
+''


### PR DESCRIPTION
Before a big refactoring and the implementation of the service registry (https://github.com/oddlama/nix-topology/issues/128), adding a couple of integration tests to make sure that service extraction and rendering won't break.

## Summary

- Adds a **service extraction test** that validates enabling NixOS services (grafana, vaultwarden, prometheus, openssh) produces correct topology entries with expected names, info fields, hidden flag propagation, and topology-level aggregation.
- Adds an **SVG render test** that validates the end-to-end pipeline from NixOS config through to well-formed SVG output containing expected service content.
- Both tests are registered as `nix flake check` derivations (Linux only).