### PR TITLE
fix(extractors/services): fix paperless domain attribute

### DIFF
--- a/nixos/extractors/services.nix
+++ b/nixos/extractors/services.nix
@@ -642,7 +642,7 @@ in
 
       paperless-ngx =
         let
-          inherit (config.services.paperless.settings) domain;
+          inherit (config.services.paperless) domain;
         in
         mkIf config.services.paperless.enable {
           name = "Paperless-ngx";


### PR DESCRIPTION
https://search.nixos.org/options?type=packages&channel=unstable&query=services.paperless.domain