### PR TITLE
fix(extractors/paperless): paperless domain null error

### DIFF
--- a/nixos/extractors/services.nix
+++ b/nixos/extractors/services.nix
@@ -642,12 +642,14 @@ in
 
       paperless-ngx =
         let
-          inherit (config.services.paperless.settings) domain;
+          domain = config.services.paperless.settings.domain or null;
+          paperlessUrl = config.services.paperless.settings.PAPERLESS_URL or null;
+          url = if domain != null then "https://${domain}" else paperlessUrl;
         in
         mkIf config.services.paperless.enable {
           name = "Paperless-ngx";
           icon = "services.paperless-ngx";
-          info = mkIf (domain != null) "https://${domain}";
+          info = mkIf (url != null) url;
           details.listen.text = "${config.services.paperless.address}:${toString config.services.paperless.port}";
         };
 


### PR DESCRIPTION
If the paperless domain is not set, nix-topology used to throw an error.
This might be the case if domain is set as PAPERLESS_URL.

My change tries to accept both cases