### PR TITLE
fix(extractors/services): harmonia wrong order

### DIFF
--- a/nixos/extractors/services.nix
+++ b/nixos/extractors/services.nix
@@ -261,7 +261,7 @@ in
 
       harmonia =
         mkIf
-          (config.services.harmonia.cache.enable or config.services.harmonia-dev.cache.enable
+          (config.services.harmonia-dev.cache.enable or config.services.harmonia.cache.enable
             or config.services.harmonia.enable or false
           )
           {


### PR DESCRIPTION
We checked an option that is always defined. This caused those who use the harmonia flake to miss out on it in the topology. With now check whether the possibly missing dev version exists and then fall back to the nixpkgs module.