### PR TITLE
Use evaluatedConfig instead of config for microvms

### DIFF
--- a/nixos/extractors/microvm.nix
+++ b/nixos/extractors/microvm.nix
@@ -16,7 +16,7 @@ let
     f:
     flip mapAttrsToList config.microvm.vms (
       vmName: vm:
-      f (if vm.flake != null then vm.flake.nixosConfigurations.${vmName}.config else vm.config.config)
+      f (if vm.flake != null then vm.flake.nixosConfigurations.${vmName}.config else if vm.evaluatedConfig != null then vm.evaluatedConfig.config else vm.config.config)
     );
 in
 {


### PR DESCRIPTION
I dynamically generate microvm.vms from self.nixosConfigurations but those are not modules but evaluated configurations so I must set vm.evaluatedConfigurations and vm.config is null

https://github.com/microvm-nix/microvm.nix/blob/3904edd282a7166cdad6c597964718e6d018baa6/nixos-modules/host/default.nix#L43-L54